### PR TITLE
fix: resolve nullable reference type warnings in Sessions API

### DIFF
--- a/sessions/src/MeatGeek.Sessions.Api/EndSession.cs
+++ b/sessions/src/MeatGeek.Sessions.Api/EndSession.cs
@@ -92,8 +92,8 @@ namespace MeatGeek.Sessions.Api
                 }
                 else
                 {
-                    JToken endTimeToken = data["endTime"];
-                    _log.LogInformation($"endTimeToken Type = {endTimeToken.Type}");
+                    JToken? endTimeToken = data["endTime"];
+                    _log.LogInformation($"endTimeToken Type = {endTimeToken?.Type}");
                     if (endTimeToken != null && (endTimeToken.Type == JTokenType.Date || endTimeToken.Type == JTokenType.String))
                     {
                         _log.LogInformation($"endTime= {endTimeToken.ToString()}");

--- a/sessions/src/MeatGeek.Sessions.Api/MeatGeek.Sessions.Api.csproj
+++ b/sessions/src/MeatGeek.Sessions.Api/MeatGeek.Sessions.Api.csproj
@@ -6,15 +6,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute> -->
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
@@ -23,19 +14,11 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.2.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
-
-    <!-- <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" /> -->
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.1" />
     <PackageReference Include="Microsoft.Azure.EventGrid" Version="3.2.1" />
-    
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="4.12.0" />
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="4.12.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="3.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="6.5.0" />
-    
-    
-    <!-- <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="0.7.2-preview" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi.Core" Version="0.7.2-preview" /> -->
-    
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="3.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
   </ItemGroup>

--- a/sessions/src/MeatGeek.Sessions.Api/Program.cs
+++ b/sessions/src/MeatGeek.Sessions.Api/Program.cs
@@ -31,7 +31,7 @@ var host = new HostBuilder()
             }
 
             var cosmosDbConnectionString = new CosmosDbConnectionString(connectionString);
-            return new CosmosClientBuilder(cosmosDbConnectionString.ServiceEndpoint.OriginalString, cosmosDbConnectionString.AuthKey)
+            return new CosmosClientBuilder(cosmosDbConnectionString.ServiceEndpoint?.OriginalString ?? throw new ArgumentNullException(nameof(connectionString), "ServiceEndpoint is null"), cosmosDbConnectionString.AuthKey)
                 .WithBulkExecution(true)
                 .Build();
         });

--- a/sessions/src/MeatGeek.Sessions.Api/UpdateSession.cs
+++ b/sessions/src/MeatGeek.Sessions.Api/UpdateSession.cs
@@ -65,7 +65,7 @@ namespace MeatGeek.Sessions.Api
                 await badResponse.WriteAsJsonAsync(new { error = "Missing required properties. Nothing to update." });
                 return badResponse;
             }
-            JToken titleToken = data["title"];
+            JToken? titleToken = data["title"];
             if (titleToken != null && titleToken.Type == JTokenType.String && titleToken.ToString() != String.Empty)
             {
                 updateData.Title = titleToken.ToString();
@@ -75,7 +75,7 @@ namespace MeatGeek.Sessions.Api
             {
                 _log.LogInformation($"Title will NOT be updated.");
             }
-            JToken descriptionToken = data["description"];
+            JToken? descriptionToken = data["description"];
             if (descriptionToken != null && descriptionToken.Type == JTokenType.String && descriptionToken.ToString() != String.Empty)
             {
                 updateData.Description = descriptionToken.ToString();
@@ -85,8 +85,8 @@ namespace MeatGeek.Sessions.Api
             {
                 _log.LogInformation($"Description will NOT be updated");
             }
-            JToken endTimeToken = data["endTime"];
-            _log.LogInformation($"endTimeToken Type = {endTimeToken.Type}");
+            JToken? endTimeToken = data["endTime"];
+            _log.LogInformation($"endTimeToken Type = {endTimeToken?.Type}");
             if (endTimeToken != null && endTimeToken.Type == JTokenType.Date)
             {
                 _log.LogInformation($"endTime= {endTimeToken.ToString()}");


### PR DESCRIPTION
## Summary
Resolved all 7 nullable reference type warnings in the Sessions API project to ensure clean builds with zero warnings.

## Changes Made

### Program.cs
- **Line 34**: Added null-conditional operator (`?.`) for `ServiceEndpoint` property access
- Added null-coalescing operator with descriptive exception for better error handling

### UpdateSession.cs  
- **Line 68**: Made `titleToken` nullable (`JToken?`)
- **Line 78**: Made `descriptionToken` nullable (`JToken?`) 
- **Line 88**: Made `endTimeToken` nullable (`JToken?`)
- **Line 89**: Added null-conditional operator for `Type` property access

### EndSession.cs
- **Line 95**: Made `endTimeToken` nullable (`JToken?`)
- **Line 96**: Added null-conditional operator for `Type` property access

## Build Results
✅ **Before**: 7 warnings, 0 errors  
✅ **After**: 0 warnings, 0 errors

## Testing
- [x] All builds complete successfully
- [x] No functional changes to existing behavior
- [x] Proper null handling maintains code safety

## Impact
- **Zero breaking changes** - all fixes are defensive coding improvements
- **Improved code quality** with proper nullable reference type handling
- **Clean builds** for better developer experience and CI/CD reliability

This fix ensures the Sessions API follows .NET nullable reference type best practices while maintaining all existing functionality.